### PR TITLE
release <- dev (2.4.7)

### DIFF
--- a/python-scripts/__init__.py
+++ b/python-scripts/__init__.py
@@ -6,7 +6,7 @@ import sys
 import os
 
 # Global Vars
-PACKAGE_VERSION = "2.4.6"
+PACKAGE_VERSION = "2.4.7"
 
 # Initial Setup - Add path and initialize logger
 if __name__ != '__main__':

--- a/python-scripts/gt_rigger_biped_gui.py
+++ b/python-scripts/gt_rigger_biped_gui.py
@@ -43,6 +43,10 @@
  Fixed select skinning for base rig (missing spine joint when simplifying)
  Added temporary select skinning joints hack for facial and corrective rigs
 
+ 2022-10-27
+ Removed proxy limiting option (implemented as attributes directly onto proxy controls)
+ Fixed an issue where the base version wouldn't update
+
 """
 from shiboken2 import wrapInstance
 from PySide2.QtWidgets import QWidget
@@ -381,22 +385,22 @@ def build_gui_auto_biped_rig():
                 c=lambda x: build_custom_help_window(realtime_custom_help_message,
                                                      realtime_custom_help_title))
 
-    # Limit Proxy Movement
-    is_option_enabled = True
-    current_bgc_color = enabled_bgc_color if is_option_enabled else disabled_bgc_color
-    cmds.text(' ', bgc=current_bgc_color, h=20)  # Tiny Empty Space
-    cmds.checkBox(label='  Limit Proxy Movement', value=data_biped.settings.get('proxy_limits'),
-                  ebg=True, cc=lambda x: _invert_stored_setting('proxy_limits', data_biped),
-                  en=is_option_enabled)
-
-    proxy_limit_custom_help_message = 'Unlocks transforms for feet and spine proxy elements. ' \
-                                      'This allows for more unconventional character shapes, but makes' \
-                                      ' the auto rigger less robust. If this is your first time using it, ' \
-                                      'you might want to keep the limits active.'
-    proxy_limit_custom_help_title = 'Limit Proxy Movement'
-    cmds.button(label='?', bgc=current_bgc_color,
-                c=lambda x: build_custom_help_window(proxy_limit_custom_help_message,
-                                                     proxy_limit_custom_help_title))
+    # # Limit Proxy Movement
+    # is_option_enabled = True
+    # current_bgc_color = enabled_bgc_color if is_option_enabled else disabled_bgc_color
+    # cmds.text(' ', bgc=current_bgc_color, h=20)  # Tiny Empty Space
+    # cmds.checkBox(label='  Limit Proxy Movement', value=data_biped.settings.get('proxy_limits'),
+    #               ebg=True, cc=lambda x: _invert_stored_setting('proxy_limits', data_biped),
+    #               en=is_option_enabled)
+    #
+    # proxy_limit_custom_help_message = 'Unlocks transforms for feet and spine proxy elements. ' \
+    #                                   'This allows for more unconventional character shapes, but makes' \
+    #                                   ' the auto rigger less robust. If this is your first time using it, ' \
+    #                                   'you might want to keep the limits active.'
+    # proxy_limit_custom_help_title = 'Limit Proxy Movement'
+    # cmds.button(label='?', bgc=current_bgc_color,
+    #             c=lambda x: build_custom_help_window(proxy_limit_custom_help_message,
+    #                                                  proxy_limit_custom_help_title))
 
     # Force Uniform Control Orientation
     is_option_enabled = True

--- a/python-scripts/gt_rigger_biped_logic.py
+++ b/python-scripts/gt_rigger_biped_logic.py
@@ -317,6 +317,12 @@
  Moved skeleton and rig setup scale constraints to base constraints group
  Added a second check to flip right ankle in case it's collapsed
 
+ 1.12.4 to 1.12.5 - 2022-10-27
+ Updated ankle proxy to follow hip by default
+ Changed ankle constraint to not affect "Y"
+ Updated some of the proxy attributes to be hidden
+ Added proxy heel visualization lines
+
  TODO Biped Rigger:
     Transfer scale information from ik spine limit spine to spines
     Add option to leave all lock translation attributes off
@@ -1177,17 +1183,33 @@ def create_biped_proxy(data_biped):
     cmds.transformLimits(right_ankle_proxy_crv, ry=(-80, 80), ery=(1, 1))
 
     # Main Control
-    cmds.setAttr(main_crv + '.translate', l=True, k=False, channelBox=False)
-    cmds.setAttr(main_crv + '.rotate', l=True, k=False, channelBox=False)
+    cmds.setAttr(main_crv + '.tx', l=True, k=False, channelBox=False)
+    cmds.setAttr(main_crv + '.ty', l=True, k=False, channelBox=False)
+    cmds.setAttr(main_crv + '.tz', l=True, k=False, channelBox=False)
+    cmds.setAttr(main_crv + '.rx', l=True, k=False, channelBox=False)
+    cmds.setAttr(main_crv + '.ry', l=True, k=False, channelBox=False)
+    cmds.setAttr(main_crv + '.rz', l=True, k=False, channelBox=False)
 
     # Other Center Joints
     cmds.setAttr(head_end_proxy_crv + '.ry', l=True, k=False, channelBox=False)
-    cmds.setAttr(spine01_proxy_crv + '.rotate', l=True, k=False, channelBox=False)
-    cmds.setAttr(spine02_proxy_crv + '.rotate', l=True, k=False, channelBox=False)
-    cmds.setAttr(spine03_proxy_crv + '.rotate', l=True, k=False, channelBox=False)
-    cmds.setAttr(spine01_proxy_crv + '.scale', l=True, k=False, channelBox=False)
-    cmds.setAttr(spine02_proxy_crv + '.scale', l=True, k=False, channelBox=False)
-    cmds.setAttr(spine03_proxy_crv + '.scale', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine01_proxy_crv + '.rx', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine01_proxy_crv + '.ry', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine01_proxy_crv + '.rz', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine02_proxy_crv + '.rx', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine02_proxy_crv + '.ry', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine02_proxy_crv + '.rz', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine03_proxy_crv + '.rx', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine03_proxy_crv + '.ry', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine03_proxy_crv + '.rz', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine01_proxy_crv + '.sx', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine01_proxy_crv + '.sy', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine01_proxy_crv + '.sz', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine02_proxy_crv + '.sx', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine02_proxy_crv + '.sy', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine02_proxy_crv + '.sz', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine03_proxy_crv + '.sx', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine03_proxy_crv + '.sy', l=True, k=False, channelBox=False)
+    cmds.setAttr(spine03_proxy_crv + '.sz', l=True, k=False, channelBox=False)
     cmds.setAttr(spine04_proxy_crv + '.ry', l=True, k=False, channelBox=False)
     cmds.setAttr(spine04_proxy_crv + '.rz', l=True, k=False, channelBox=False)
     cmds.setAttr(neck_base_proxy_crv + '.ry', l=True, k=False, channelBox=False)
@@ -1222,31 +1244,22 @@ def create_biped_proxy(data_biped):
     cmds.setAttr(spine03_proxy_grp + '.v', l=True, k=False, channelBox=False)
 
     # Arms
-    cmds.setAttr(left_shoulder_proxy_crv + '.rotate', l=True, k=False, channelBox=False)
-    cmds.setAttr(right_shoulder_proxy_crv + '.rotate', l=True, k=False, channelBox=False)
-    cmds.setAttr(left_shoulder_proxy_crv + '.scale', l=True, k=False, channelBox=False)
-    cmds.setAttr(right_shoulder_proxy_crv + '.scale', l=True, k=False, channelBox=False)
+    lock_hide_default_attr(left_shoulder_proxy_crv, translate=False, visibility=False)
+    lock_hide_default_attr(right_shoulder_proxy_crv, translate=False, visibility=False)
 
+    lock_hide_default_attr(left_elbow_proxy_crv, rotate=False, translate=False, visibility=False)
+    lock_hide_default_attr(right_elbow_proxy_crv, rotate=False, translate=False, visibility=False)
     cmds.setAttr(left_elbow_proxy_crv + '.rotate', l=True, k=False, channelBox=False)
     cmds.setAttr(right_elbow_proxy_crv + '.rotate', l=True, k=False, channelBox=False)
-    cmds.setAttr(left_elbow_proxy_crv + '.scale', l=True, k=False, channelBox=False)
-    cmds.setAttr(right_elbow_proxy_crv + '.scale', l=True, k=False, channelBox=False)
 
     # Legs
-    # cmds.setAttr(right_hip_proxy_crv + '.tz', l=True, k=False, channelBox=False)
-    # cmds.setAttr(left_hip_proxy_crv + '.tz', l=True, k=False, channelBox=False)
+    lock_hide_default_attr(right_hip_proxy_crv, translate=False, visibility=False)
+    lock_hide_default_attr(left_hip_proxy_crv, translate=False, visibility=False)
 
-    cmds.setAttr(right_hip_proxy_crv + '.rotate', l=True, k=False, channelBox=False)
-    cmds.setAttr(left_hip_proxy_crv + '.rotate', l=True, k=False, channelBox=False)
-
-    cmds.setAttr(right_hip_proxy_crv + '.scale', l=True, k=False, channelBox=False)
-    cmds.setAttr(left_hip_proxy_crv + '.scale', l=True, k=False, channelBox=False)
-
-    cmds.setAttr(right_knee_proxy_crv + '.rotate', l=True, k=False, channelBox=False)
-    cmds.setAttr(left_knee_proxy_crv + '.rotate', l=True, k=False, channelBox=False)
-
-    cmds.setAttr(right_knee_proxy_crv + '.scale', l=True, k=False, channelBox=False)
-    cmds.setAttr(left_knee_proxy_crv + '.scale', l=True, k=False, channelBox=False)
+    lock_hide_default_attr(right_knee_proxy_crv, rotate=False, translate=False, visibility=False)
+    lock_hide_default_attr(left_knee_proxy_crv, rotate=False, translate=False, visibility=False)
+    cmds.setAttr(right_knee_proxy_crv + '.rotate', l=True, k=False, channelBox=False)  # Retain channel visibility
+    cmds.setAttr(left_knee_proxy_crv + '.rotate', l=True, k=False, channelBox=False)  # Retain channel visibility
 
     # Feet
     cmds.setAttr(right_ball_proxy_crv + '.rz', l=True, k=False, channelBox=False)
@@ -1261,7 +1274,7 @@ def create_biped_proxy(data_biped):
     cmds.setAttr(left_toe_proxy_crv + '.rx', l=True, k=False, channelBox=False)
     cmds.setAttr(left_toe_proxy_crv + '.rz', l=True, k=False, channelBox=False)
 
-    # Special Cases
+    # Special Cases --------------------
     if settings.get('proxy_limits'):
         cmds.setAttr(left_ball_proxy_crv + '.ty', l=True, k=False, channelBox=False)
         cmds.setAttr(left_toe_proxy_crv + '.ty', l=True, k=False, channelBox=False)
@@ -1285,6 +1298,17 @@ def create_biped_proxy(data_biped):
 
         cmds.setAttr(jaw_proxy_crv + '.tx', l=True, k=False, channelBox=False)
         cmds.setAttr(jaw_end_proxy_crv + '.tx', l=True, k=False, channelBox=False)
+
+    # Lock Knee Unstable Channels
+    for knee_ctrl in [right_knee_proxy_crv, left_knee_proxy_crv]:
+        cmds.addAttr(knee_ctrl, ln=CUSTOM_ATTR_SEPARATOR, at='enum', en='-------------:', keyable=True)
+        cmds.setAttr(knee_ctrl + '.' + CUSTOM_ATTR_SEPARATOR, lock=True)
+        cmds.addAttr(knee_ctrl, ln='lockUnstableChannel', at='bool', k=True)
+        cmds.setAttr(knee_ctrl + '.lockUnstableChannel', 1)
+        cmds.setAttr(knee_ctrl + '.minTransXLimit', 0)
+        cmds.setAttr(knee_ctrl + '.maxTransXLimit', 0)
+        cmds.connectAttr(knee_ctrl + '.lockUnstableChannel', knee_ctrl + '.minTransXLimitEnable', f=True)
+        cmds.connectAttr(knee_ctrl + '.lockUnstableChannel', knee_ctrl + '.maxTransXLimitEnable', f=True)
 
     # Set Loc Visibility
     cmds.setAttr(left_knee_upvec_loc[0] + '.v', 0)
@@ -1332,15 +1356,15 @@ def create_biped_proxy(data_biped):
     cmds.addAttr(left_ankle_proxy_crv, ln="proxyControl", at='enum', en='-------------:', keyable=True)
     cmds.setAttr(left_ankle_proxy_crv + '.proxyControl', e=True, lock=True)
     cmds.addAttr(left_ankle_proxy_crv, ln="followHip", at="bool", keyable=True)
-    cmds.setAttr(left_ankle_proxy_crv + '.followHip', 0)
-    constraint = cmds.pointConstraint(left_hip_proxy_crv, left_ankle_proxy_grp, maintainOffset=True)
+    cmds.setAttr(left_ankle_proxy_crv + '.followHip', 1)
+    constraint = cmds.pointConstraint(left_hip_proxy_crv, left_ankle_proxy_grp, maintainOffset=True, skip='y')
     cmds.connectAttr(left_ankle_proxy_crv + '.followHip', constraint[0] + '.w0')
 
     cmds.addAttr(right_ankle_proxy_crv, ln="proxyControl", at='enum', en='-------------:', keyable=True)
     cmds.setAttr(right_ankle_proxy_crv + '.proxyControl', e=True, lock=True)
     cmds.addAttr(right_ankle_proxy_crv, ln="followHip", at="bool", keyable=True)
-    cmds.setAttr(right_ankle_proxy_crv + '.followHip', 0)
-    constraint = cmds.pointConstraint(right_hip_proxy_crv, right_ankle_proxy_grp, maintainOffset=True)
+    cmds.setAttr(right_ankle_proxy_crv + '.followHip', 1)
+    constraint = cmds.pointConstraint(right_hip_proxy_crv, right_ankle_proxy_grp, maintainOffset=True, skip='y')
     cmds.connectAttr(right_ankle_proxy_crv + '.followHip', constraint[0] + '.w0')
 
     # Store new names into settings in case they were modified
@@ -1598,6 +1622,8 @@ def create_biped_proxy(data_biped):
                                            elements.get('left_pinky03_proxy_crv')),
                  create_visualization_line(elements.get('left_pinky03_proxy_crv'),
                                            elements.get('left_pinky04_proxy_crv')),
+                 create_visualization_line(elements.get('left_ankle_proxy_crv'),
+                                           elements.get('left_heel_proxy_pivot')),
                  # Right Side
 
                  create_visualization_line(elements.get('hip_proxy_crv'),
@@ -1659,7 +1685,9 @@ def create_biped_proxy(data_biped):
                  create_visualization_line(elements.get('right_pinky02_proxy_crv'),
                                            elements.get('right_pinky03_proxy_crv')),
                  create_visualization_line(elements.get('right_pinky03_proxy_crv'),
-                                           elements.get('right_pinky04_proxy_crv'))
+                                           elements.get('right_pinky04_proxy_crv')),
+                 create_visualization_line(elements.get('right_ankle_proxy_crv'),
+                                           elements.get('right_heel_proxy_pivot'))
                  ]
 
     lines_grp = cmds.group(name='visualization_lines', empty=True, world=True)
@@ -10173,7 +10201,7 @@ def create_biped_rig(data_biped):
                                rig_joints_default.get('main_jnt'),
                                main_ctrl, new_skeleton_suffix)
 
-        # Re-parent Constraints @@@
+        # Re-parent Constraints
         reparent_constraints(rig_joints_default.get('main_jnt'), constraints_automation_grp) # Main joint is now Game
 
     # ################ Store Created Joints #################
@@ -10388,4 +10416,4 @@ def build_test_biped_rig(create_rig_ctrls=True, debugging=True):
 
 # Test it
 if __name__ == '__main__':
-    build_test_biped_rig(create_rig_ctrls=True, debugging=True)
+    build_test_biped_rig(create_rig_ctrls=False, debugging=True)

--- a/python-scripts/gt_rigger_data.py
+++ b/python-scripts/gt_rigger_data.py
@@ -27,7 +27,7 @@ logger = logging.getLogger("gt_rigger_data")
 logger.setLevel(logging.INFO)
 
 # Versions
-SCRIPT_VERSION_BASE = '1.12.5'
+SCRIPT_VERSION_BASE = '1.12.6'
 SCRIPT_VERSION_FACIAL = '1.0.9'
 SCRIPT_VERSION_CORRECTIVE = '1.0.7'
 SCRIPT_VERSION_REBUILD = '0.0.9'
@@ -150,7 +150,6 @@ class GTBipedRiggerData:
     # Store Default Values
     def __init__(self):
         self.settings = {'using_no_ssc_skeleton': False,
-                         'proxy_limits': False,
                          'offer_heel_roll_positioning': True,
                          'uniform_ctrl_orient': True,
                          'worldspace_ik_orient': False,

--- a/python-scripts/gt_rigger_data.py
+++ b/python-scripts/gt_rigger_data.py
@@ -26,7 +26,8 @@ logging.basicConfig()
 logger = logging.getLogger("gt_rigger_data")
 logger.setLevel(logging.INFO)
 
-SCRIPT_VERSION_BASE = '1.12.3'
+# Versions
+SCRIPT_VERSION_BASE = '1.12.5'
 SCRIPT_VERSION_FACIAL = '1.0.9'
 SCRIPT_VERSION_CORRECTIVE = '1.0.7'
 SCRIPT_VERSION_REBUILD = '0.0.9'


### PR DESCRIPTION
- Fixed an issue where the biped interface would leave a locator behind when crashing during a pose mirror
- Updated biped proxy stability
    - Removed proxy limiting option
    - Added optional proxy limiting attributes directly to affected controls
    - Increased knee stability by locking unstable channel by default ("X")
    - Changed ankle behaviour to follow hip by default
    - Changed ankle follow method to not affect "Y" position