### PR TITLE
MacOS clean-up and updater error

### DIFF
--- a/gt/tools/package_updater/__init__.py
+++ b/gt/tools/package_updater/__init__.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 # Tool Version
-__version_tuple__ = (2, 0, 1)
+__version_tuple__ = (2, 0, 2)
 __version_suffix__ = ''
 __version__ = '.'.join(str(n) for n in __version_tuple__) + __version_suffix__
 

--- a/gt/tools/package_updater/package_updater_model.py
+++ b/gt/tools/package_updater/package_updater_model.py
@@ -197,6 +197,8 @@ class PackageUpdaterModel:
         if not version_utils.is_semantic_version(self.installed_version, metadata_ok=False) or \
                 not version_utils.is_semantic_version(self.latest_github_version, metadata_ok=False):
             self.status = "Unknown"
+            self.latest_github_version = "0.0.0"
+            return
         comparison_result = version_utils.compare_versions(self.installed_version, self.latest_github_version)
         self.comparison_result = comparison_result
         if comparison_result == version_utils.VERSION_BIGGER:

--- a/gt/tools/package_updater/package_updater_model.py
+++ b/gt/tools/package_updater/package_updater_model.py
@@ -351,6 +351,7 @@ class PackageUpdaterModel:
             _cache = cache
         else:
             _cache = PackageCache()
+
         cache_dir = _cache.get_cache_dir()
         cache_download = os.path.join(cache_dir, "package_update.zip")
         cache_extract = os.path.join(cache_dir, "update_extract")

--- a/gt/utils/data_utils.py
+++ b/gt/utils/data_utils.py
@@ -203,7 +203,7 @@ class PermissionBits:
     READ_WRITE = READ_ONLY | WRITE_ONLY
     READ_EXECUTE = READ_ONLY | EXECUTE_ONLY
     WRITE_EXECUTE = WRITE_ONLY | EXECUTE_ONLY
-    ALL_PERMISSIONS = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
+    ALL_PERMISSIONS = 438  # Owner: Read (4) + Write (2) Group: Read (4) Others: Read (4)
 
 
 def set_file_permissions(file_path, permission_bits, keep_current=False):

--- a/gt/utils/request_utils.py
+++ b/gt/utils/request_utils.py
@@ -77,7 +77,7 @@ def http_get_request(url, timeout_ms=2000, host_overwrite=None, path_overwrite=N
         connection.close()
         return response, response_content
     except Exception as e:
-        logger.warning(f'Unable to retrieve response. Issue: {e}')
+        logger.warning(f'Unable to get HTTP response. Issue: {e}')
         return None, None
 
 

--- a/tests/test_package_updater/test_package_updater_model.py
+++ b/tests/test_package_updater/test_package_updater_model.py
@@ -268,6 +268,19 @@ class TestCurveLibraryModel(unittest.TestCase):
         temp_dir_extract = os.path.join(temp_dir, PACKAGE_MAIN_MODULE, "extracted")
         os.makedirs(temp_dir_extract)
         mocked_os_dir.return_value = [temp_dir_extract]
+
+        class MockedPackageCache:
+            @staticmethod
+            def get_cache_dir():
+                return temp_dir
+
+            def add_path_to_cache_list(self, path_to_add):
+                pass
+
+            def clear_cache(self):
+                pass
+
+        mocked_cache.return_value = MockedPackageCache()
         self.model.update_package(cache=None, force_update=False)
         mocked_cache.assert_called()
         mocked_os_dir.assert_called()

--- a/tests/test_utils/test_curve_utils.py
+++ b/tests/test_utils/test_curve_utils.py
@@ -580,7 +580,7 @@ class TestCurveUtils(unittest.TestCase):
                                       value=0)
         curve_utils.write_curve_files_from_selection(target_dir=temp_folder)
         expected = ['curve_01.crv', 'curve_02.crv']
-        result = os.listdir(temp_folder)
+        result = sorted(os.listdir(temp_folder))  # Sorted because MacOS might change the order
         self.assertEqual(expected, result)
         curve_file = os.path.join(temp_folder, 'curve_01.crv')
         with open(curve_file, 'r') as file:
@@ -681,12 +681,12 @@ class TestCurveUtils(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_create_text(self):
-        result = curve_utils.create_text("curve")
+        result = curve_utils.create_text("curve", font="Arial")
         expected = "curve_crv"
         self.assertEqual(expected, result)
 
     def test_create_text_shapes(self):
-        curve = curve_utils.create_text("curve")
+        curve = curve_utils.create_text("curve", font="Arial")
         result = maya_test_tools.list_relatives(curve, shapes=True)
         expected = ['curve_crv_01Shape', 'curve_crv_02Shape', 'curve_crv_03Shape',
                     'curve_crv_04Shape', 'curve_crv_05Shape', 'curve_crv_06Shape']

--- a/tests/test_utils/test_data_utils.py
+++ b/tests/test_utils/test_data_utils.py
@@ -1,4 +1,3 @@
-from unittest.mock import patch, Mock
 import unittest
 import logging
 import json
@@ -18,6 +17,7 @@ package_root_dir = os.path.dirname(tests_dir)
 for to_append in [package_root_dir, tests_dir]:
     if to_append not in sys.path:
         sys.path.append(to_append)
+from gt.utils.data_utils import PermissionBits
 from tests import maya_test_tools
 from gt.utils import data_utils
 
@@ -150,9 +150,11 @@ class TestDataUtils(unittest.TestCase):
 
     def test_set_file_permissions(self):
         test_file = self.create_temp_test_file()
-        test_permission_bits = 438
-        data_utils.set_file_permissions(test_file, data_utils.PermissionBits.ALL_PERMISSIONS)
-        self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode), test_permission_bits)
+        # test_permission_bits = 438
+        test_permission_bits = PermissionBits.ALL_PERMISSIONS
+        data_utils.set_file_permissions(test_file, PermissionBits.ALL_PERMISSIONS)
+        file_mode = stat.S_IMODE(os.lstat(test_file).st_mode)
+        self.assertEqual(file_mode, test_permission_bits)
 
     def test_set_file_permissions_raises_error(self):
         # Test that FileNotFoundError is raised for non-existent file
@@ -162,15 +164,19 @@ class TestDataUtils(unittest.TestCase):
 
     def test_set_file_permission_read_only(self):
         test_file = self.create_temp_test_file()
-        test_permission_bits = 292
+        #test_permission_bits = 292
+        test_permission_bits = PermissionBits.READ_ONLY
         data_utils.set_file_permission_read_only(test_file)
+        file_mode = stat.S_IMODE(os.lstat(test_file).st_mode)
         self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode), test_permission_bits)
 
     def test_set_file_permission_modifiable(self):
         test_file = self.create_temp_test_file()
-        test_permission_bits = 438
+        #test_permission_bits = 438
+        test_permission_bits = PermissionBits.ALL_PERMISSIONS
         data_utils.set_file_permission_modifiable(test_file)
-        self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode), test_permission_bits)
+        file_mode = stat.S_IMODE(os.lstat(test_file).st_mode)
+        self.assertEqual(file_mode, test_permission_bits)
 
     def test_data_dir_constants(self):
         path_attributes = vars(data_utils.DataDirConstants)
@@ -190,7 +196,7 @@ class TestDataUtils(unittest.TestCase):
 
         # Check if the extracted file exists
         self.assertTrue(os.path.exists(extract_path))
-        result = os.listdir(extract_path)
+        result = sorted(os.listdir(extract_path))  # Sorted for MacOS
         expected = ['script_01.py', 'text_01.txt', 'text_02.txt']
         self.assertEqual(expected, result)
 
@@ -209,7 +215,7 @@ class TestDataUtils(unittest.TestCase):
 
         # Check if the extracted file exists
         self.assertTrue(os.path.exists(extract_path))
-        expected = [os.path.join(extract_path, file) for file in os.listdir(extract_path)]
+        expected = sorted([os.path.join(extract_path, file) for file in os.listdir(extract_path)])
         self.assertEqual(expected, result)
 
     def test_progress_callback(self):

--- a/tests/test_utils/test_data_utils.py
+++ b/tests/test_utils/test_data_utils.py
@@ -164,7 +164,6 @@ class TestDataUtils(unittest.TestCase):
 
     def test_set_file_permission_read_only(self):
         test_file = self.create_temp_test_file()
-        #test_permission_bits = 292
         test_permission_bits = PermissionBits.READ_ONLY
         data_utils.set_file_permission_read_only(test_file)
         file_mode = stat.S_IMODE(os.lstat(test_file).st_mode)
@@ -172,11 +171,10 @@ class TestDataUtils(unittest.TestCase):
 
     def test_set_file_permission_modifiable(self):
         test_file = self.create_temp_test_file()
-        #test_permission_bits = 438
         test_permission_bits = PermissionBits.ALL_PERMISSIONS
         data_utils.set_file_permission_modifiable(test_file)
         file_mode = stat.S_IMODE(os.lstat(test_file).st_mode)
-        self.assertEqual(file_mode, test_permission_bits)
+        self.assertEqual(test_permission_bits, file_mode)
 
     def test_data_dir_constants(self):
         path_attributes = vars(data_utils.DataDirConstants)

--- a/tests/test_utils/test_setup_utils.py
+++ b/tests/test_utils/test_setup_utils.py
@@ -569,7 +569,7 @@ class TestSetupUtils(unittest.TestCase):
     def test_get_installed_module_path(self, mocked_get_prefs):
         mocked_get_prefs.return_value = "mocked_path"
         result = setup_utils.get_installed_core_module_path()
-        expected = 'mocked_path\\gt-tools\\gt'
+        expected = os.path.join("mocked_path", "gt-tools", "gt")
         self.assertEqual(expected, result)
 
     @patch('gt.utils.setup_utils.get_maya_preferences_dir')


### PR DESCRIPTION
- Fixed a MacOS issue that would cause package updater not to refresh its view.
- Fixed a few unittests failing on MacOS

Tests MacOS:
| Test Runner Summary |     |
|---------------------|-----|
| Ran                 | 436 |
| Failed              | 0   |

Tests Windows:
| Test Runner Summary |     |
|---------------------|-----|
| Ran                 | 436 |
| Failed              | 0   |