### PR TITLE
release <- dev (3.1.2)

### DIFF
--- a/gt/__init__.py
+++ b/gt/__init__.py
@@ -3,7 +3,7 @@ import gt.utils
 import sys
 
 # Package Variables
-__version_tuple__ = (3, 1, 1)
+__version_tuple__ = (3, 1, 2)
 __version_suffix__ = ''
 __version__ = '.'.join(str(n) for n in __version_tuple__) + __version_suffix__
 __authors__ = ['Guilherme Trevisan']

--- a/gt/tools/curve_library/__init__.py
+++ b/gt/tools/curve_library/__init__.py
@@ -5,10 +5,8 @@
 from gt.tools.curve_library import curve_library_controller
 from gt.tools.curve_library import curve_library_model
 from gt.tools.curve_library import curve_library_view
-from PySide2.QtWidgets import QApplication
-from gt.utils import session_utils
+from gt.ui import qt_utils
 import logging
-import sys
 
 # Logging Setup
 logging.basicConfig()
@@ -16,49 +14,21 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 # Tool Version
-__version_tuple__ = (1, 0, 1)
+__version_tuple__ = (1, 0, 2)
 __version_suffix__ = ''
 __version__ = '.'.join(str(n) for n in __version_tuple__) + __version_suffix__
-
-
-def build_curve_library_gui(standalone=True):
-    """
-    Creates Model, View and Controller
-    Args:
-        standalone (bool, optional): If true, it will run the tool without the Maya window dependency.
-                                     If false, it will attempt to retrieve the name of the main maya window as parent.
-    """
-    # Determine Parent
-    if session_utils.is_script_in_py_maya():
-        app = QApplication(sys.argv)
-        _view = curve_library_view.CurveLibraryWindow(version=__version__)
-    else:
-        from gt.ui.qt_utils import get_maya_main_window
-        maya_window = get_maya_main_window()
-        _view = curve_library_view.CurveLibraryWindow(parent=maya_window, version=__version__)
-
-    # Create connections
-    _model = curve_library_model.CurveLibraryModel()
-    _controller = curve_library_controller.CurveLibraryController(model=_model, view=_view)
-
-    # Show window
-    if standalone:
-        _view.show()
-        sys.exit(app.exec_())
-    else:
-        _view.show()
-    return _view
 
 
 def launch_tool():
     """
     Launch user interface and create any necessary connections for the tool to function.
     Entry point for when using this tool.
+    Creates Model, View and Controller and uses QtApplicationContext to determine context (inside of Maya or not?)
     """
-    if session_utils.is_script_in_py_maya():
-        build_curve_library_gui(standalone=True)
-    else:
-        build_curve_library_gui(standalone=False)
+    with qt_utils.QtApplicationContext() as context:
+        _view = curve_library_view.CurveLibraryWindow(parent=context.get_parent(), version=__version__)
+        _model = curve_library_model.CurveLibraryModel()
+        _controller = curve_library_controller.CurveLibraryController(model=_model, view=_view)
 
 
 if __name__ == "__main__":

--- a/gt/tools/curve_library/curve_library_controller.py
+++ b/gt/tools/curve_library/curve_library_controller.py
@@ -30,6 +30,7 @@ class CurveLibraryController:
         self.view.item_list.itemSelectionChanged.connect(self.on_item_selection_changed)
         self.view.search_edit.textChanged.connect(self.filter_list)
         self.populate_curve_library()
+        self.view.show()
 
     def on_item_selection_changed(self):
         """

--- a/gt/tools/curve_library/curve_library_view.py
+++ b/gt/tools/curve_library/curve_library_view.py
@@ -4,13 +4,14 @@ Curve Library Window - The main GUI window class for the Curve Library tool.
 from PySide2.QtWidgets import QListWidget, QPushButton, QDialog, QWidget, QSplitter, QLineEdit, QDesktopWidget
 import gt.ui.resource_library as resource_library
 from gt.ui.squared_widget import SquaredWidget
+from gt.ui.qt_utils import MayaDockableMeta
 from PySide2.QtGui import QIcon, QPixmap
 from PySide2 import QtWidgets, QtCore
 import gt.ui.qt_utils as qt_utils
 import sys
 
 
-class CurveLibraryWindow(QDialog):
+class CurveLibraryWindow(metaclass=MayaDockableMeta, base_inheritance=QDialog):
     def __init__(self, parent=None, controller=None, version=None):
         """
         Initialize the CurveLibraryWindow.
@@ -22,6 +23,7 @@ class CurveLibraryWindow(QDialog):
                                                  the garbage collector.  Defaults to None.
             version (str, optional): If provided, it will be used to determine the window title. e.g. Title - (v1.2.3)
         """
+        # super(CurveLibraryWindow, self).__init__(parent=parent)
         super().__init__(parent=parent)
         self.controller = controller  # Only here so it doesn't get deleted by the garbage collectors
         self.splitter = None
@@ -151,5 +153,5 @@ class CurveLibraryWindow(QDialog):
 if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)  # Application - To launch without Maya
     window = CurveLibraryWindow()  # View
-    window.show()  # Open Windows
+    window.show()
     sys.exit(app.exec_())

--- a/gt/tools/curve_library/curve_library_view.py
+++ b/gt/tools/curve_library/curve_library_view.py
@@ -1,17 +1,16 @@
 """
 Curve Library Window - The main GUI window class for the Curve Library tool.
 """
-from PySide2.QtWidgets import QListWidget, QPushButton, QDialog, QWidget, QSplitter, QLineEdit, QDesktopWidget
+from PySide2.QtWidgets import QListWidget, QPushButton, QWidget, QSplitter, QLineEdit, QDesktopWidget
 import gt.ui.resource_library as resource_library
 from gt.ui.squared_widget import SquaredWidget
-from gt.ui.qt_utils import MayaDockableMeta
+from gt.ui.qt_utils import MayaWindowMeta
 from PySide2.QtGui import QIcon, QPixmap
 from PySide2 import QtWidgets, QtCore
 import gt.ui.qt_utils as qt_utils
-import sys
 
 
-class CurveLibraryWindow(metaclass=MayaDockableMeta, base_inheritance=QDialog):
+class CurveLibraryWindow(metaclass=MayaWindowMeta):
     def __init__(self, parent=None, controller=None, version=None):
         """
         Initialize the CurveLibraryWindow.
@@ -151,7 +150,6 @@ class CurveLibraryWindow(metaclass=MayaDockableMeta, base_inheritance=QDialog):
 
 
 if __name__ == "__main__":
-    app = QtWidgets.QApplication(sys.argv)  # Application - To launch without Maya
-    window = CurveLibraryWindow()  # View
-    window.show()
-    sys.exit(app.exec_())
+    with qt_utils.QtApplicationContext():
+        window = CurveLibraryWindow()
+        window.show()

--- a/gt/tools/package_setup/__init__.py
+++ b/gt/tools/package_setup/__init__.py
@@ -5,52 +5,20 @@
 from gt.tools.package_setup import setup_controller
 from gt.tools.package_setup import setup_model
 from gt.tools.package_setup import setup_view
-from PySide2.QtWidgets import QApplication
-from gt.utils import session_utils
-from gt.utils import setup_utils
-import sys
+from gt.ui import qt_utils
 
 # Tool Version
-__version_tuple__ = (1, 0, 0)
+__version_tuple__ = (1, 0, 1)
 __version_suffix__ = ''
 __version__ = '.'.join(str(n) for n in __version_tuple__) + __version_suffix__
 
 
-def build_installer_gui(standalone=True):
-    """
-    Creates installer GUI
-    Args:
-        standalone (bool, optional): If true, it will run the tool without the Maya window dependency.
-                                     If false, it will attempt to retrieve the name of the main maya window as parent.
-    """
-    # Determine Parent
-    if standalone:
-        app = QApplication(sys.argv)
-        _view = setup_view.PackageSetupWindow()
-    else:
-        from gt.ui.qt_utils import get_maya_main_window
-        maya_window = get_maya_main_window()
-        _view = setup_view.PackageSetupWindow(parent=maya_window)
-
-    _model = setup_model.PackageSetupModel()
-    _controller = setup_controller.PackageSetupController(model=_model, view=_view)
-
-    # Show window
-    if standalone:
-        _view.show()
-        sys.exit(app.exec_())
-    else:
-        _view.show()
-    return _view
-
-
 def launcher_entry_point():
     """ Determines if it should open the installer GUI as a child of Maya or by itself """
-    setup_utils.reload_package_loaded_modules()
-    if session_utils.is_script_in_py_maya():
-        build_installer_gui(standalone=True)
-    else:
-        build_installer_gui(standalone=False)
+    with qt_utils.QtApplicationContext() as context:
+        _view = setup_view.PackageSetupWindow(parent=context.get_parent())
+        _model = setup_model.PackageSetupModel()
+        _controller = setup_controller.PackageSetupController(model=_model, view=_view)
 
 
 def open_about_window():

--- a/gt/tools/package_setup/__init__.py
+++ b/gt/tools/package_setup/__init__.py
@@ -8,13 +8,7 @@ from gt.tools.package_setup import setup_view
 from PySide2.QtWidgets import QApplication
 from gt.utils import session_utils
 from gt.utils import setup_utils
-import logging
 import sys
-
-# Logging Setup
-logging.basicConfig()
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 # Tool Version
 __version_tuple__ = (1, 0, 0)

--- a/gt/tools/package_setup/setup_controller.py
+++ b/gt/tools/package_setup/setup_controller.py
@@ -36,6 +36,9 @@ class PackageSetupController:
         self.model.update_status()
         self.model.update_version()
 
+        # Show
+        self.view.show()
+
 
 if __name__ == "__main__":
     controller = PackageSetupController(None, None)

--- a/gt/tools/package_setup/setup_view.py
+++ b/gt/tools/package_setup/setup_view.py
@@ -3,6 +3,7 @@ Package Setup View - GUI
 """
 from PySide2.QtWidgets import QToolButton, QSizePolicy
 import gt.ui.resource_library as resource_library
+from gt.ui.qt_utils import MayaWindowMeta
 from PySide2 import QtWidgets, QtCore
 import gt.ui.qt_utils as qt_utils
 from PySide2.QtGui import QIcon
@@ -10,7 +11,7 @@ from PySide2.QtCore import Qt
 import sys
 
 
-class PackageSetupWindow(QtWidgets.QDialog):
+class PackageSetupWindow(metaclass=MayaWindowMeta):
     """
     PackageSetupWindow class represents a dialog window for package setup.
 
@@ -246,14 +247,12 @@ class PackageSetupWindow(QtWidgets.QDialog):
 
 
 if __name__ == "__main__":
-    # Application - To launch without Maya
-    app = QtWidgets.QApplication(sys.argv)
-    # Connections
-    window = PackageSetupWindow()  # View
-    # Sample Updates
-    window.update_status_text(r"Not Installed")
-    window.update_version_current_setup("3.0.0")
-    window.update_version_installed("2.5.5")
-    # Open Windows
-    window.show()
-    sys.exit(app.exec_())
+    with qt_utils.QtApplicationContext():
+        # Connections
+        window = PackageSetupWindow()  # View
+        # Sample Updates
+        window.update_status_text(r"Not Installed")
+        window.update_version_current_setup("3.0.0")
+        window.update_version_installed("2.5.5")
+        # Open Windows
+        window.show()

--- a/gt/tools/package_updater/__init__.py
+++ b/gt/tools/package_updater/__init__.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 # Tool Version
-__version_tuple__ = (2, 0, 1)
+__version_tuple__ = (2, 0, 2)
 __version_suffix__ = ''
 __version__ = '.'.join(str(n) for n in __version_tuple__) + __version_suffix__
 

--- a/gt/tools/package_updater/__init__.py
+++ b/gt/tools/package_updater/__init__.py
@@ -17,17 +17,19 @@
  Added output message for when changing auto check or interval values
  Fixed an issue where it wouldn't be able to make an HTTP request on Maya 2023+
 
- 2.0.0 - 2023-08-08
+ 2.0.0 to 2.0.2 - 2023-08-08 to 2023-08-16
  Renamed tool from "GT Check for Updates" to "Package Updater".
  Updated to the test-driven development pattern.
  Recreated the update system to automatically download, extract and install update.
  Updated preferences system to use package variables instead of maya option vars
+ Made tool dockable
 """
 from gt.tools.package_updater import package_updater_controller
 from gt.tools.package_updater import package_updater_model
 from gt.tools.package_updater import package_updater_view
 from PySide2.QtWidgets import QApplication
 from gt.utils import session_utils
+from gt.ui import qt_utils
 import threading
 import logging
 import sys
@@ -44,34 +46,22 @@ __version_suffix__ = ''
 __version__ = '.'.join(str(n) for n in __version_tuple__) + __version_suffix__
 
 
-def build_package_updater_gui(standalone=True, model=None):
+def build_package_updater_gui(model=None):
     """
     Creates Model, View and Controller
     Args:
-        standalone (bool, optional): If true, it will run the tool without the Maya window dependency.
-                                     If false, it will attempt to retrieve the name of the main maya window as parent.
         model (PackageUpdaterModel, optional): If provided, the function will use the existing model
                                                instead of creating a new one, thus using the existing request data.
     """
     # Determine Parent
-    if session_utils.is_script_in_py_maya():
-        app = QApplication(sys.argv)
-        _view = package_updater_view.PackageUpdaterView(version=__version__)
-    else:
-        from gt.ui.qt_utils import get_maya_main_window
-        maya_window = get_maya_main_window()
-        _view = package_updater_view.PackageUpdaterView(parent=maya_window, version=__version__)
-
-    # Create connections
-    if model:
-        _model = model
-    else:
-        _model = package_updater_model.PackageUpdaterModel()
-    _controller = package_updater_controller.PackageUpdaterController(model=_model, view=_view)
-    _view.adjust_size()
-    # Show window
-    if standalone:
-        sys.exit(app.exec_())
+    # _standalone = session_utils.is_script_in_py_maya()
+    with qt_utils.QtApplicationContext() as context:
+        _view = package_updater_view.PackageUpdaterView(parent=context.get_parent(), version=__version__)
+        if model:
+            _model = model
+        else:
+            _model = package_updater_model.PackageUpdaterModel()
+        _controller = package_updater_controller.PackageUpdaterController(model=_model, view=_view)
 
 
 def silently_check_for_updates():
@@ -89,7 +79,7 @@ def silently_check_for_updates():
         _model.check_for_updates()
         _model.save_last_check_date_as_now()
         if _model.is_update_needed():
-            build_package_updater_gui(standalone=False, model=_model)
+            build_package_updater_gui(model=_model)
 
     def _maya_retrieve_update_data():
         """ Internal function used to run a thread in Maya """
@@ -108,12 +98,9 @@ def launch_tool():
     Launch user interface and create any necessary connections for the tool to function.
     Entry point for when using this tool.
     """
-    if session_utils.is_script_in_py_maya():
-        build_package_updater_gui(standalone=True)
-    else:
-        build_package_updater_gui(standalone=False)
+    build_package_updater_gui()
 
 
 if __name__ == "__main__":
     logger.setLevel(logging.DEBUG)
-    # launch_tool()
+    launch_tool()

--- a/gt/tools/package_updater/__init__.py
+++ b/gt/tools/package_updater/__init__.py
@@ -68,14 +68,10 @@ def build_package_updater_gui(standalone=True, model=None):
     else:
         _model = package_updater_model.PackageUpdaterModel()
     _controller = package_updater_controller.PackageUpdaterController(model=_model, view=_view)
-
+    _view.adjust_size()
     # Show window
     if standalone:
-        _view.show()
         sys.exit(app.exec_())
-    else:
-        _view.show()
-    return _view
 
 
 def silently_check_for_updates():

--- a/gt/tools/package_updater/package_updater_controller.py
+++ b/gt/tools/package_updater/package_updater_controller.py
@@ -44,6 +44,8 @@ class PackageUpdaterController:
             self.refresh_updater_data_threaded_maya()
         else:
             self.refresh_view_values()
+        self.view.show()
+        self.view.adjust_size()
 
     def update_view_status_with_color(self, status):
         """

--- a/gt/tools/package_updater/package_updater_controller.py
+++ b/gt/tools/package_updater/package_updater_controller.py
@@ -45,7 +45,6 @@ class PackageUpdaterController:
         else:
             self.refresh_view_values()
         self.view.show()
-        self.view.adjust_size()
 
     def update_view_status_with_color(self, status):
         """

--- a/gt/tools/package_updater/package_updater_model.py
+++ b/gt/tools/package_updater/package_updater_model.py
@@ -197,6 +197,8 @@ class PackageUpdaterModel:
         if not version_utils.is_semantic_version(self.installed_version, metadata_ok=False) or \
                 not version_utils.is_semantic_version(self.latest_github_version, metadata_ok=False):
             self.status = "Unknown"
+            self.latest_github_version = "0.0.0"
+            return
         comparison_result = version_utils.compare_versions(self.installed_version, self.latest_github_version)
         self.comparison_result = comparison_result
         if comparison_result == version_utils.VERSION_BIGGER:

--- a/gt/tools/package_updater/package_updater_model.py
+++ b/gt/tools/package_updater/package_updater_model.py
@@ -351,6 +351,7 @@ class PackageUpdaterModel:
             _cache = cache
         else:
             _cache = PackageCache()
+
         cache_dir = _cache.get_cache_dir()
         cache_download = os.path.join(cache_dir, "package_update.zip")
         cache_extract = os.path.join(cache_dir, "update_extract")

--- a/gt/tools/package_updater/package_updater_view.py
+++ b/gt/tools/package_updater/package_updater_view.py
@@ -10,7 +10,7 @@ import gt.ui.qt_utils as qt_utils
 from PySide2.QtCore import Qt
 
 
-class PackageUpdaterView(metaclass=MayaWindowMeta, dockable=True):
+class PackageUpdaterView(metaclass=MayaWindowMeta):
     def __init__(self, parent=None, controller=None, version=None):
         """
         Initialize the PackageUpdater.
@@ -64,7 +64,8 @@ class PackageUpdaterView(metaclass=MayaWindowMeta, dockable=True):
         stylesheet += resource_library.Stylesheet.dark_list_widget
         self.setStyleSheet(stylesheet)
         self.update_btn.setStyleSheet(resource_library.Stylesheet.bright_push_button)
-        self.adjust_size()
+        qt_utils.resize_to_screen(self, percentage=35, width_percentage=30)
+        qt_utils.center_window(self)
         # self.setWindowFlag(QtCore.Qt.Tool, True)  # Stay On Top Modality - Fixes Mac order issue
 
     def create_widgets(self):
@@ -167,33 +168,6 @@ class PackageUpdaterView(metaclass=MayaWindowMeta, dockable=True):
         main_layout.setContentsMargins(15, 15, 15, 15)  # Make Margins Uniform LTRB
         main_layout.addLayout(top_layout)
         main_layout.addLayout(bottom_layout)
-
-    def adjust_size(self):
-        """ Adjusts size of the window """
-        # qt_utils.resize_to_screen(self, percentage=35, width_percentage=30)
-        # qt_utils.center_window(self)
-        # TEMP
-        from PySide2.QtWidgets import QApplication, QWidget, QDesktopWidget, QDialog, QMainWindow
-        from gt.utils.session_utils import is_script_in_interactive_maya
-        from PySide2.QtGui import QFontDatabase, QColor, QFont
-        from gt.utils.system_utils import get_system, OS_MAC
-        from PySide2 import QtGui, QtCore, QtWidgets
-        from PySide2.QtCore import QPoint
-
-        screen_geometry = QDesktopWidget().availableGeometry(self)
-        width = self.geometry().width()
-        height = self.geometry().height()
-        print(width)
-        print(height)
-
-        height = 735
-        width = 630
-        self.resize(width, height)
-        width2 = self.geometry().width()
-        height2 = self.geometry().height()
-        print(width2)
-        print(height2)
-
 
     def change_update_button_state(self, state):
         """
@@ -338,17 +312,16 @@ class PackageUpdaterView(metaclass=MayaWindowMeta, dockable=True):
 
 
 if __name__ == "__main__":
-    # app = QtWidgets.QApplication(sys.argv)  # Application - To launch without Maya
-    window = PackageUpdaterView(version="1.2.3")  # View
-    window.change_update_button_state(state=False)
-    window.add_text_to_changelog("hello hello helo hello")
-    window.add_text_to_changelog("hello hello helo hello", text_color_hex="#0000FF")
-    window.update_status("New Update Available!", text_color_hex="black", bg_color_hex="#FF7F7F")
-    window.update_web_response("OK")
-    window.update_installed_version("v1.2.3")
-    window.update_latest_release("v4.5.6")
-    window.update_auto_check_status_btn(False)
-    window.update_interval_button(5)
-    window.change_interval_button_state(False)
-    window.show()
-    # sys.exit(app.exec_())
+    with qt_utils.QtApplicationContext():
+        window = PackageUpdaterView(version="1.2.3")  # View
+        window.change_update_button_state(state=False)
+        window.add_text_to_changelog("hello hello helo hello")
+        window.add_text_to_changelog("hello hello helo hello", text_color_hex="#0000FF")
+        window.update_status("New Update Available!", text_color_hex="black", bg_color_hex="#FF7F7F")
+        window.update_web_response("OK")
+        window.update_installed_version("v1.2.3")
+        window.update_latest_release("v4.5.6")
+        window.update_auto_check_status_btn(False)
+        window.update_interval_button(5)
+        window.change_interval_button_state(False)
+        window.show()

--- a/gt/tools/package_updater/package_updater_view.py
+++ b/gt/tools/package_updater/package_updater_view.py
@@ -4,13 +4,14 @@ Curve Library Window - The main GUI window class for the Curve Library tool.
 from PySide2.QtWidgets import QPushButton, QDialog, QLabel, QTextEdit, QVBoxLayout, QHBoxLayout
 import gt.ui.resource_library as resource_library
 from PySide2 import QtWidgets, QtCore, QtGui
-import gt.ui.qt_utils as qt_utils
 from PySide2.QtGui import QIcon, QTextCursor
+from gt.ui.qt_utils import MayaDockableMeta
+import gt.ui.qt_utils as qt_utils
 from PySide2.QtCore import Qt
 import sys
 
 
-class PackageUpdaterView(QDialog):
+class PackageUpdaterView(metaclass=MayaDockableMeta, base_inheritance=QDialog):
     def __init__(self, parent=None, controller=None, version=None):
         """
         Initialize the PackageUpdater.

--- a/gt/tools/package_updater/package_updater_view.py
+++ b/gt/tools/package_updater/package_updater_view.py
@@ -1,17 +1,16 @@
 """
 Curve Library Window - The main GUI window class for the Curve Library tool.
 """
-from PySide2.QtWidgets import QPushButton, QDialog, QLabel, QTextEdit, QVBoxLayout, QHBoxLayout
+from PySide2.QtWidgets import QPushButton, QLabel, QTextEdit, QVBoxLayout, QHBoxLayout
 import gt.ui.resource_library as resource_library
 from PySide2 import QtWidgets, QtCore, QtGui
 from PySide2.QtGui import QIcon, QTextCursor
-from gt.ui.qt_utils import MayaDockableMeta
+from gt.ui.qt_utils import MayaWindowMeta
 import gt.ui.qt_utils as qt_utils
 from PySide2.QtCore import Qt
-import sys
 
 
-class PackageUpdaterView(metaclass=MayaDockableMeta, base_inheritance=QDialog):
+class PackageUpdaterView(metaclass=MayaWindowMeta, dockable=True):
     def __init__(self, parent=None, controller=None, version=None):
         """
         Initialize the PackageUpdater.
@@ -24,6 +23,7 @@ class PackageUpdaterView(metaclass=MayaDockableMeta, base_inheritance=QDialog):
             version (str, optional): If provided, it will be used to determine the window title. e.g. Title - (v1.2.3)
         """
         super().__init__(parent=parent)
+
         self.controller = controller  # Only here so it doesn't get deleted by the garbage collectors
         # Labels
         self.title_label = None
@@ -64,8 +64,7 @@ class PackageUpdaterView(metaclass=MayaDockableMeta, base_inheritance=QDialog):
         stylesheet += resource_library.Stylesheet.dark_list_widget
         self.setStyleSheet(stylesheet)
         self.update_btn.setStyleSheet(resource_library.Stylesheet.bright_push_button)
-        qt_utils.resize_to_screen(self, percentage=35, width_percentage=30)
-        qt_utils.center_window(self)
+        self.adjust_size()
         # self.setWindowFlag(QtCore.Qt.Tool, True)  # Stay On Top Modality - Fixes Mac order issue
 
     def create_widgets(self):
@@ -168,6 +167,33 @@ class PackageUpdaterView(metaclass=MayaDockableMeta, base_inheritance=QDialog):
         main_layout.setContentsMargins(15, 15, 15, 15)  # Make Margins Uniform LTRB
         main_layout.addLayout(top_layout)
         main_layout.addLayout(bottom_layout)
+
+    def adjust_size(self):
+        """ Adjusts size of the window """
+        # qt_utils.resize_to_screen(self, percentage=35, width_percentage=30)
+        # qt_utils.center_window(self)
+        # TEMP
+        from PySide2.QtWidgets import QApplication, QWidget, QDesktopWidget, QDialog, QMainWindow
+        from gt.utils.session_utils import is_script_in_interactive_maya
+        from PySide2.QtGui import QFontDatabase, QColor, QFont
+        from gt.utils.system_utils import get_system, OS_MAC
+        from PySide2 import QtGui, QtCore, QtWidgets
+        from PySide2.QtCore import QPoint
+
+        screen_geometry = QDesktopWidget().availableGeometry(self)
+        width = self.geometry().width()
+        height = self.geometry().height()
+        print(width)
+        print(height)
+
+        height = 735
+        width = 630
+        self.resize(width, height)
+        width2 = self.geometry().width()
+        height2 = self.geometry().height()
+        print(width2)
+        print(height2)
+
 
     def change_update_button_state(self, state):
         """
@@ -312,9 +338,8 @@ class PackageUpdaterView(metaclass=MayaDockableMeta, base_inheritance=QDialog):
 
 
 if __name__ == "__main__":
-    app = QtWidgets.QApplication(sys.argv)  # Application - To launch without Maya
+    # app = QtWidgets.QApplication(sys.argv)  # Application - To launch without Maya
     window = PackageUpdaterView(version="1.2.3")  # View
-    window.show()  # Open Windows
     window.change_update_button_state(state=False)
     window.add_text_to_changelog("hello hello helo hello")
     window.add_text_to_changelog("hello hello helo hello", text_color_hex="#0000FF")
@@ -325,4 +350,5 @@ if __name__ == "__main__":
     window.update_auto_check_status_btn(False)
     window.update_interval_button(5)
     window.change_interval_button_state(False)
-    sys.exit(app.exec_())
+    window.show()
+    # sys.exit(app.exec_())

--- a/gt/tools/path_manager/__init__.py
+++ b/gt/tools/path_manager/__init__.py
@@ -36,6 +36,13 @@
  Aligned path to the left
  Added padding to table cells
 """
+import logging
+
+# Logging Setup
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 # Tool Version
 __version_tuple__ = (1, 2, 3)
 __version_suffix__ = ''
@@ -52,9 +59,8 @@ def launch_tool():
     try:
         path_manager_dialog.close()
         path_manager_dialog.deleteLater()
-    except Exception as exception:
-        print(exception)
-        pass
+    except Exception as e:
+        logger.debug(f'Initializing tool variable for the first time. Debug description: "{str(e)}".')
     path_manager.try_to_close_gt_path_manager()
     path_manager_dialog = path_manager.GTPathManagerDialog()
     path_manager_dialog.show()

--- a/gt/tools/sample_tool/__init__.py
+++ b/gt/tools/sample_tool/__init__.py
@@ -5,10 +5,8 @@
 from gt.tools.sample_tool import sample_controller
 from gt.tools.sample_tool import sample_model
 from gt.tools.sample_tool import sample_view
-from PySide2.QtWidgets import QApplication
-from gt.utils import session_utils
+from gt.ui import qt_utils
 import logging
-import sys
 
 # Logging Setup
 logging.basicConfig()
@@ -21,45 +19,16 @@ __version_suffix__ = ''
 __version__ = '.'.join(str(n) for n in __version_tuple__) + __version_suffix__
 
 
-def build_sample_tool_gui(standalone=True):
-    """
-    Creates Model, View and Controller
-    Args:
-        standalone (bool, optional): If true, it will run the tool without the Maya window dependency.
-                                     If false, it will attempt to retrieve the name of the main maya window as parent.
-    """
-    # Determine Parent
-    if session_utils.is_script_in_py_maya():
-        app = QApplication(sys.argv)
-        _view = sample_view.SampleToolWindow()
-    else:
-        from gt.ui.qt_utils import get_maya_main_window
-        maya_window = get_maya_main_window()
-        _view = sample_view.SampleToolWindow(parent=maya_window)
-
-    # Create connections
-    _model = sample_model.SampleToolModel()
-    _controller = sample_controller.SampleToolController(model=_model, view=_view)
-    _controller.update_view()
-
-    # Show window
-    if standalone:
-        _view.show()
-        sys.exit(app.exec_())
-    else:
-        _view.show()
-    return _view
-
-
 def launch_tool():
     """
     Launch user interface and create any necessary connections for the tool to function.
     Entry point for when using this tool.
+    Creates Model, View and Controller
     """
-    if session_utils.is_script_in_py_maya():
-        build_sample_tool_gui(standalone=True)
-    else:
-        build_sample_tool_gui(standalone=False)
+    with qt_utils.QtApplicationContext() as context:
+        _view = sample_view.SampleToolWindow(parent=context.get_parent())
+        _model = sample_model.SampleToolModel()
+        _controller = sample_controller.SampleToolController(model=_model, view=_view)
 
 
 if __name__ == "__main__":

--- a/gt/tools/sample_tool/sample_controller.py
+++ b/gt/tools/sample_tool/sample_controller.py
@@ -31,6 +31,8 @@ class SampleToolController:
         self.view.add_button.clicked.connect(self.add_item_view)
         self.view.remove_button.clicked.connect(self.remove_item_view)
         self.view.controller = self
+        self.view.show()
+        self.update_view()
 
     def add_item_view(self):
         """

--- a/gt/utils/data_utils.py
+++ b/gt/utils/data_utils.py
@@ -203,7 +203,7 @@ class PermissionBits:
     READ_WRITE = READ_ONLY | WRITE_ONLY
     READ_EXECUTE = READ_ONLY | EXECUTE_ONLY
     WRITE_EXECUTE = WRITE_ONLY | EXECUTE_ONLY
-    ALL_PERMISSIONS = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
+    ALL_PERMISSIONS = 438  # Owner: Read (4) + Write (2) Group: Read (4) Others: Read (4)
 
 
 def set_file_permissions(file_path, permission_bits, keep_current=False):

--- a/gt/utils/request_utils.py
+++ b/gt/utils/request_utils.py
@@ -77,7 +77,7 @@ def http_get_request(url, timeout_ms=2000, host_overwrite=None, path_overwrite=N
         connection.close()
         return response, response_content
     except Exception as e:
-        logger.warning(f'Unable to retrieve response. Issue: {e}')
+        logger.warning(f'Unable to get HTTP response. Issue: {e}')
         return None, None
 
 

--- a/gt/utils/system_utils.py
+++ b/gt/utils/system_utils.py
@@ -6,6 +6,7 @@ github.com/TrevisanGMW/gt-tools
 from gt.utils.data_utils import DataDirConstants
 from functools import wraps
 import subprocess
+import importlib
 import tempfile
 import logging
 import pathlib
@@ -618,6 +619,32 @@ def execute_deferred(func, *args, **kwargs):
         exec(func)
     else:
         func(*args, **kwargs)
+
+
+def import_from_path(path):
+    """
+    Dynamically imports modules or objects using their full path.
+
+    Args:
+        path (str): The full path to the module or object (e.g., "module.submodule" or "module.submodule.ClassName").
+
+    Returns:
+        type: The imported module or object if successful, otherwise None.
+    """
+    try:
+        module_path, object_name = path.rsplit('.', 1)
+        module = importlib.import_module(module_path)
+
+        if object_name:
+            imported_object = getattr(module, object_name, None)
+            if imported_object is not None:
+                return imported_object
+        else:
+            return module
+
+        return None
+    except (ImportError, AttributeError, ValueError, ModuleNotFoundError) as e:
+        return None
 
 
 if __name__ == "__main__":

--- a/tests/test_package_updater/test_package_updater_model.py
+++ b/tests/test_package_updater/test_package_updater_model.py
@@ -268,6 +268,19 @@ class TestCurveLibraryModel(unittest.TestCase):
         temp_dir_extract = os.path.join(temp_dir, PACKAGE_MAIN_MODULE, "extracted")
         os.makedirs(temp_dir_extract)
         mocked_os_dir.return_value = [temp_dir_extract]
+
+        class MockedPackageCache:
+            @staticmethod
+            def get_cache_dir():
+                return temp_dir
+
+            def add_path_to_cache_list(self, path_to_add):
+                pass
+
+            def clear_cache(self):
+                pass
+
+        mocked_cache.return_value = MockedPackageCache()
         self.model.update_package(cache=None, force_update=False)
         mocked_cache.assert_called()
         mocked_os_dir.assert_called()

--- a/tests/test_utils/test_curve_utils.py
+++ b/tests/test_utils/test_curve_utils.py
@@ -580,7 +580,7 @@ class TestCurveUtils(unittest.TestCase):
                                       value=0)
         curve_utils.write_curve_files_from_selection(target_dir=temp_folder)
         expected = ['curve_01.crv', 'curve_02.crv']
-        result = os.listdir(temp_folder)
+        result = sorted(os.listdir(temp_folder))  # Sorted because MacOS might change the order
         self.assertEqual(expected, result)
         curve_file = os.path.join(temp_folder, 'curve_01.crv')
         with open(curve_file, 'r') as file:
@@ -681,12 +681,12 @@ class TestCurveUtils(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_create_text(self):
-        result = curve_utils.create_text("curve")
+        result = curve_utils.create_text("curve", font="Arial")
         expected = "curve_crv"
         self.assertEqual(expected, result)
 
     def test_create_text_shapes(self):
-        curve = curve_utils.create_text("curve")
+        curve = curve_utils.create_text("curve", font="Arial")
         result = maya_test_tools.list_relatives(curve, shapes=True)
         expected = ['curve_crv_01Shape', 'curve_crv_02Shape', 'curve_crv_03Shape',
                     'curve_crv_04Shape', 'curve_crv_05Shape', 'curve_crv_06Shape']

--- a/tests/test_utils/test_data_utils.py
+++ b/tests/test_utils/test_data_utils.py
@@ -1,4 +1,3 @@
-from unittest.mock import patch, Mock
 import unittest
 import logging
 import json
@@ -18,6 +17,7 @@ package_root_dir = os.path.dirname(tests_dir)
 for to_append in [package_root_dir, tests_dir]:
     if to_append not in sys.path:
         sys.path.append(to_append)
+from gt.utils.data_utils import PermissionBits
 from tests import maya_test_tools
 from gt.utils import data_utils
 
@@ -150,9 +150,11 @@ class TestDataUtils(unittest.TestCase):
 
     def test_set_file_permissions(self):
         test_file = self.create_temp_test_file()
-        test_permission_bits = 438
-        data_utils.set_file_permissions(test_file, data_utils.PermissionBits.ALL_PERMISSIONS)
-        self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode), test_permission_bits)
+        # test_permission_bits = 438
+        test_permission_bits = PermissionBits.ALL_PERMISSIONS
+        data_utils.set_file_permissions(test_file, PermissionBits.ALL_PERMISSIONS)
+        file_mode = stat.S_IMODE(os.lstat(test_file).st_mode)
+        self.assertEqual(file_mode, test_permission_bits)
 
     def test_set_file_permissions_raises_error(self):
         # Test that FileNotFoundError is raised for non-existent file
@@ -162,15 +164,19 @@ class TestDataUtils(unittest.TestCase):
 
     def test_set_file_permission_read_only(self):
         test_file = self.create_temp_test_file()
-        test_permission_bits = 292
+        #test_permission_bits = 292
+        test_permission_bits = PermissionBits.READ_ONLY
         data_utils.set_file_permission_read_only(test_file)
+        file_mode = stat.S_IMODE(os.lstat(test_file).st_mode)
         self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode), test_permission_bits)
 
     def test_set_file_permission_modifiable(self):
         test_file = self.create_temp_test_file()
-        test_permission_bits = 438
+        #test_permission_bits = 438
+        test_permission_bits = PermissionBits.ALL_PERMISSIONS
         data_utils.set_file_permission_modifiable(test_file)
-        self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode), test_permission_bits)
+        file_mode = stat.S_IMODE(os.lstat(test_file).st_mode)
+        self.assertEqual(file_mode, test_permission_bits)
 
     def test_data_dir_constants(self):
         path_attributes = vars(data_utils.DataDirConstants)
@@ -190,7 +196,7 @@ class TestDataUtils(unittest.TestCase):
 
         # Check if the extracted file exists
         self.assertTrue(os.path.exists(extract_path))
-        result = os.listdir(extract_path)
+        result = sorted(os.listdir(extract_path))  # Sorted for MacOS
         expected = ['script_01.py', 'text_01.txt', 'text_02.txt']
         self.assertEqual(expected, result)
 
@@ -209,7 +215,7 @@ class TestDataUtils(unittest.TestCase):
 
         # Check if the extracted file exists
         self.assertTrue(os.path.exists(extract_path))
-        expected = [os.path.join(extract_path, file) for file in os.listdir(extract_path)]
+        expected = sorted([os.path.join(extract_path, file) for file in os.listdir(extract_path)])
         self.assertEqual(expected, result)
 
     def test_progress_callback(self):

--- a/tests/test_utils/test_data_utils.py
+++ b/tests/test_utils/test_data_utils.py
@@ -164,7 +164,6 @@ class TestDataUtils(unittest.TestCase):
 
     def test_set_file_permission_read_only(self):
         test_file = self.create_temp_test_file()
-        #test_permission_bits = 292
         test_permission_bits = PermissionBits.READ_ONLY
         data_utils.set_file_permission_read_only(test_file)
         file_mode = stat.S_IMODE(os.lstat(test_file).st_mode)
@@ -172,11 +171,10 @@ class TestDataUtils(unittest.TestCase):
 
     def test_set_file_permission_modifiable(self):
         test_file = self.create_temp_test_file()
-        #test_permission_bits = 438
         test_permission_bits = PermissionBits.ALL_PERMISSIONS
         data_utils.set_file_permission_modifiable(test_file)
         file_mode = stat.S_IMODE(os.lstat(test_file).st_mode)
-        self.assertEqual(file_mode, test_permission_bits)
+        self.assertEqual(test_permission_bits, file_mode)
 
     def test_data_dir_constants(self):
         path_attributes = vars(data_utils.DataDirConstants)

--- a/tests/test_utils/test_setup_utils.py
+++ b/tests/test_utils/test_setup_utils.py
@@ -569,7 +569,7 @@ class TestSetupUtils(unittest.TestCase):
     def test_get_installed_module_path(self, mocked_get_prefs):
         mocked_get_prefs.return_value = "mocked_path"
         result = setup_utils.get_installed_core_module_path()
-        expected = 'mocked_path\\gt-tools\\gt'
+        expected = os.path.join("mocked_path", "gt-tools", "gt")
         self.assertEqual(expected, result)
 
     @patch('gt.utils.setup_utils.get_maya_preferences_dir')

--- a/tests/test_utils/test_system_utils.py
+++ b/tests/test_utils/test_system_utils.py
@@ -485,3 +485,26 @@ class TestSystemUtils(unittest.TestCase):
     def test_execute_deferred_called(self, mocked_maya_state):
         system_utils.execute_deferred(func="logger.debug('')")
         mocked_maya_state.assert_called_once()
+
+    def test_successful_import(self):
+        # Test importing a valid class
+        imported_object = system_utils.import_from_path('math.sqrt')
+        import math
+        self.assertEqual(math.sqrt, imported_object)
+
+    def test_import_non_class_int(self):
+        imported_object = system_utils.import_from_path('builtins.int')
+        self.assertEqual(int, imported_object)
+
+    def test_import_non_class_print(self):
+        """
+        Test importing a non-class object.
+        """
+        imported_object = system_utils.import_from_path("builtins.print")
+        import builtins
+        self.assertEqual(imported_object, builtins.print)
+
+    def test_import_invalid_path(self):
+        # Test importing an invalid class path
+        imported_object = system_utils.import_from_path('nonexistent_module.NonexistentClass')
+        self.assertIsNone(imported_object)


### PR DESCRIPTION
- Created QtApplicationContext to automatically detect when using Qt in Maya or outside.
- Created Dockable QT Metaclass
- Updated initialization method of the Curve Library, Package Setup, Package Updater and Sample Tool.
- Made Curve Library, Package Setup, Package Updater and Sample Tool dockable in Maya.
- Fixed issue where windows would fall behind Maya on MacOS
- Fixed permission issues on Windows
- Fixed warning message when failing to get HTTP response on MacOS

Tests:
| Test Runner Summary |     |
|---------------------|-----|
| Ran                 | 440 |
| Failed              | 0   |